### PR TITLE
Fix: cross-device link not permitted

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -441,7 +441,8 @@ class asterisk extends utils.Adapter {
         if (!this.config.ssh) {
             const audiofile_local_gsm = tools.addSlashToPath(this.config.path) + path.basename(audiofile_guid_gsm);
             this.log.debug(`move ${audiofile_guid_gsm} ${audiofile_local_gsm}`);
-            fs.renameSync(audiofile_guid_gsm, audiofile_local_gsm);
+            fs.copyFileSync(audiofile_guid_gsm, audiofile_local_gsm);
+            fs.rmSync(audiofile_guid_gsm);
             if (parameter.variable) {
                 parameter.variable.file = tools.getFilenameWithoutExtension(audiofile_local_gsm);
                 parameter.variable.del = 'delete';
@@ -488,7 +489,8 @@ class asterisk extends utils.Adapter {
         if (!this.config.ssh) {
             const audiofile_local_gsm = tools.addSlashToPath(this.config.path) + path.basename(audiofile_guid_gsm);
             this.log.debug(`move ${audiofile_guid_gsm} ${audiofile_local_gsm}`);
-            fs.renameSync(audiofile_guid_gsm, audiofile_local_gsm);
+            fs.copyFileSync(audiofile_guid_gsm, audiofile_local_gsm);
+            fs.rmSync(audiofile_guid_gsm);
             parameter.audiofile = tools.getFilenameWithoutExtension(audiofile_local_gsm);
             parameter.delete = 'delete';
         }
@@ -642,7 +644,8 @@ class asterisk extends utils.Adapter {
         if (!this.config.ssh) {
             const audiofile_dtmf_gsm = `${tools.addSlashToPath(this.config.path)}asterisk_dtmf.gsm`;
             this.log.debug(`move ${audiofile_guid_gsm} ${audiofile_dtmf_gsm}`);
-            fs.renameSync(audiofile_guid_gsm, audiofile_dtmf_gsm);
+            fs.copyFileSync(audiofile_guid_gsm, audiofile_dtmf_gsm);
+            fs.rmSync(audiofile_guid_gsm);
         }
     }
 }


### PR DESCRIPTION
Since updating to the latest version I always get the following error message:
Error in onStateChange: dialout.call:  EXDEV: cross-device link not permitted, rename '/tmp/audio_dc2c3292-1e65-f0cf-6469-9f4c62723a30.gsm' -> '/opt/asterisk2/audio_dc2c3292-1e65-f0cf-6469-9f4c62723a30.gsm'

The problem is that I have tmp and opt/asterisk mounted on different partitions. Rename only works on the same partition. Therefore, I suggest copying the file first and then deleting it. After that, it works for me without having to rebuild the server.